### PR TITLE
Added an exclusion for the "credentials/" directory to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Credentials
+credentials/


### PR DESCRIPTION
This change will prevent leaking sensitive files to the remote repository.